### PR TITLE
TCDM: Quicker Update Rate for the Car's Speedometer

### DIFF
--- a/bin/x64/plugins/cyber_engine_tweaks/mods/TravelingCompanionDistanceMeter/init.lua
+++ b/bin/x64/plugins/cyber_engine_tweaks/mods/TravelingCompanionDistanceMeter/init.lua
@@ -66,22 +66,22 @@ function travelingCompanionDistanceMeter:new()
                 -- The speed reading in the 3rd person cam
                 if(travelingCompanionDistanceMeterConfig.convertSpeedometerToMPH) then
                     Override("hudCarController", "OnSpeedValueChanged", function (zelf, speedValue)
-                        inkTextRef.SetText(zelf.SpeedValue, string.format("%.0f", tcdm.output.displayedSpeed * 0.621371192) .. " mph" );
+                        inkTextRef.SetText(zelf.SpeedValue, string.format("%.0f", tcdm.output.speed * 0.621371192) .. " mph" );
                     end)
 
                     -- The speedometer inside the vehicle
                     Override("speedometerLogicController", "OnSpeedValueChanged", function (zelf, speedValue)
-                        inkTextRef.SetText(zelf.speedTextWidget, string.format("%.0f", tcdm.output.displayedSpeed * 0.621371192) .. " mph");
+                        inkTextRef.SetText(zelf.speedTextWidget, string.format("%.0f", tcdm.output.speed * 0.621371192) .. " mph");
                     end)
                 else
                     -- The speed reading in the 3rd person cam
                     Override("hudCarController", "OnSpeedValueChanged", function (zelf, speedValue)
-                        inkTextRef.SetText(zelf.SpeedValue, string.format("%.0f", tcdm.output.displayedSpeed) .. " km/h");
+                        inkTextRef.SetText(zelf.SpeedValue, string.format("%.0f", tcdm.output.speed) .. " km/h");
                     end)
 
                     -- The speedometer inside the vehicle
                     Override("speedometerLogicController", "OnSpeedValueChanged", function (zelf, speedValue)
-                        inkTextRef.SetText(zelf.speedTextWidget, string.format("%.0f", tcdm.output.displayedSpeed) .. " km/h");
+                        inkTextRef.SetText(zelf.speedTextWidget, string.format("%.0f", tcdm.output.speed) .. " km/h");
                     end)
                 end
             else


### PR DESCRIPTION
This change lets the game decide when to display the new speed reading.

So far, TCDM has been having a new speed computation on every 2nd frame, but it has been controlling the update of the value in the UI, with an assumed benefit for the stability of the displayed number. As much as that may be true, it is not what the drivers want. They appreciate get- ting speed updates as they happen. Hence, the change.